### PR TITLE
feat: enable busy polling for lower latency add net.core.busy_read = 100 to sysctl defaults

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-base (4.15) unstable; urgency=medium
+
+  * linux-sysctl-defaults: Enable busy polling for lower latency
+    - Add net.core.busy_read = 100
+
+ -- zengwei <zengwei@uniontech.com>  Tue, 17 Jun 2026 10:00:00 +0800
+
 linux-base (4.14) unstable; urgency=medium
 
   * Upload to unstable

--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -60,3 +60,6 @@ fs.protected_fifos = 1
 # games.  Core dumps with > 65530 mappings will use extended section
 # numbering.
 vm.max_map_count = 1048576
+
+# Enable busy polling for lower latency
+net.core.busy_read = 100


### PR DESCRIPTION
feat: enable busy polling for lower latency ,add net.core.busy_read = 100 to sysctl defaults